### PR TITLE
Error Handling for Non Profit Class

### DIFF
--- a/backend/middleware/errors/nonprofit-errors.js
+++ b/backend/middleware/errors/nonprofit-errors.js
@@ -1,0 +1,17 @@
+import express from "express";
+
+export class NonProfitNotFoundError extends Error {
+  constructor(message) {
+    super(`Id: ${message}`);
+    this.name = "NonProfitNotFoundError";
+    this.statusCode = 400;
+  }
+}
+
+export class NonProfitAlreadyExistsError extends Error {
+  constructor(message) {
+    super(`Id: ${message}`);
+    this.name = "NonProfitAlreadyExistsError";
+    this.statusCode = 400;
+  }
+}

--- a/backend/middleware/errors/nonprofit-errors.js
+++ b/backend/middleware/errors/nonprofit-errors.js
@@ -1,5 +1,8 @@
 import express from "express";
 
+/**
+ * Error to be thrown when the non profit to be changed can not be found
+ */
 export class NonProfitNotFoundError extends Error {
   constructor(message) {
     super(`Id: ${message}`);
@@ -8,6 +11,9 @@ export class NonProfitNotFoundError extends Error {
   }
 }
 
+/**
+ * Error to be thrown when the non profit to be created already exists
+ */
 export class NonProfitAlreadyExistsError extends Error {
   constructor(message) {
     super(`Id: ${message}`);

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
   },
   "imports": {
     "#utils/*": "./utils/*",
-    "#prisma/*": "./generated/prisma/*"
+    "#prisma/*": "./generated/prisma/*",
+    "#errors/*": "./middleware/errors/*"
   }
 }

--- a/backend/routes/nonprofit.js
+++ b/backend/routes/nonprofit.js
@@ -19,85 +19,67 @@ nonprofitRouter.get("/all", async (req, res) => {
 });
 
 // Get one nonprofit by name
-nonprofitRouter.get("/:nonprofit_name", async (req, res) => {
-  const { nonprofit_name } = req.params;
-  const findNonProfit = await prisma.nonprofit.findUnique({
+nonprofitRouter.get("/:nonprofitname", async (req, res) => {
+  const { nonprofitname } = req.params;
+  const findCard = await prisma.nonprofit.findUnique({
     where: {
-      name: nonprofit_name,
+      name: nonprofitname,
     },
   });
-  if (findNonProfit) {
-    res.status(200).json(findNonProfit);
-  } else {
-    res.status(404).send(`Nonprofit ${nonprofit_name} not found`);
-  }
+  res.status(200).json(findCard);
 });
 
-// Get one nonprofit by id
-nonprofitRouter.get("/id/:nonprofit_id", async (req, res) => {
-  const { nonprofit_id } = req.params;
-  const findNonProfit = await prisma.nonprofit.findUnique({
-    where: {
-      id: nonprofit_id,
-    },
-  });
-  if (findNonProfit) {
-    res.status(200).json(findNonProfit);
-  } else {
-    res.status(404).send(`Nonprofit ${nonprofit_id} not found`);
-  }
-});
-
-// Add a new nonprofit by id
+// Add a new nonprofit by name
 nonprofitRouter.post("/add", async (req, res) => {
   const nonProfitData = req.body;
   const name = nonProfitData.name;
-  const exists = await checkNonProfitName(name);
 
-  if (!exists) {
+  const findCards = await prisma.nonprofit.findUnique({
+    where: {
+      name: name,
+    },
+  });
+  if (!findCards) {
     const createNonProfit = await prisma.nonprofit.create({
       data: nonProfitData,
     });
     res.status(201).json(createNonProfit);
   } else {
-    res.status(400).send(`Nonprofit ${name} already exists`);
+    req.status(400).json({ message: "Nonprofit already exists" });
   }
 });
 
-// Edit a nonprofit by id
-nonprofitRouter.put("/:nonprofit_id/edit", async (req, res) => {
-  const { nonprofit_id } = req.params;
+// Edit a nonprofit by name
+nonprofitRouter.put("/:nonprofitname/edit", async (req, res) => {
+  const { nonprofitname } = req.params;
   const nonProfitData = req.body;
-  const exists = await checkNonProfitId(nonprofit_id);
-
-  if (exists) {
+  try {
     const updateOne = await prisma.nonprofit.update({
       where: {
-        id: nonprofit_id,
+        name: nonprofitname,
       },
+
       data: nonProfitData,
     });
     res.json(updateOne);
     res.status(214).send();
-  } else {
-    res.status(404).send(`Nonprofit ${nonprofit_id} not found`);
+  } catch (PrismaClientKnownRequestError) {
+    res.status(404).send("Nonprofit not found");
   }
 });
 
-// Delete a nonprofit by id
-nonprofitRouter.delete("/:nonprofit_id/delete", async (req, res) => {
-  const { nonprofit_id } = req.params;
-  const exists = await checkNonProfitId(nonprofit_id);
-
-  if (exists) {
+// Delete a nonprofit by name
+nonprofitRouter.delete("/:nonprofitname/delete", async (req, res) => {
+  const { nonprofitname } = req.params;
+  try {
     await prisma.nonprofit.delete({
       where: {
-        id: nonprofit_id,
+        name: nonprofitname,
       },
     });
-    res.status(214).send(`Nonprofit ${nonprofit_id} deleted`);
-  } else {
-    res.status(404).send(`Nonprofit ${nonprofit_id} not found`);
+    res.status(214).send();
+  } catch (PrismaClientKnownRequestError) {
+    res.status(404).send("Nonprofit not found");
   }
 });
 

--- a/backend/routes/nonprofit.js
+++ b/backend/routes/nonprofit.js
@@ -21,12 +21,12 @@ nonprofitRouter.get("/all", async (req, res) => {
 // Get one nonprofit by name
 nonprofitRouter.get("/:nonprofitname", async (req, res) => {
   const { nonprofitname } = req.params;
-  const findCard = await prisma.nonprofit.findUnique({
+  const findNonProfit = await prisma.nonprofit.findUnique({
     where: {
       name: nonprofitname,
     },
   });
-  res.status(200).json(findCard);
+  res.status(200).json(findNonProfit);
 });
 
 // Add a new nonprofit by name
@@ -34,12 +34,12 @@ nonprofitRouter.post("/add", async (req, res) => {
   const nonProfitData = req.body;
   const name = nonProfitData.name;
 
-  const findCards = await prisma.nonprofit.findUnique({
+  const findNonProfits = await prisma.nonprofit.findUnique({
     where: {
       name: name,
     },
   });
-  if (!findCards) {
+  if (!findNonProfits) {
     const createNonProfit = await prisma.nonprofit.create({
       data: nonProfitData,
     });

--- a/backend/routes/nonprofit.js
+++ b/backend/routes/nonprofit.js
@@ -46,7 +46,7 @@ nonprofitRouter.get("/:nonprofit_name", async (req, res, next) => {
 });
 
 // Get one nonprofit by id
-nonprofitRouter.get("/id/:nonprofit_id", async (req, res) => {
+nonprofitRouter.get("/id/:nonprofit_id", async (req, res, next) => {
   const { nonprofit_id } = req.params;
   try {
     const findNonProfit = await prisma.nonprofit.findUnique({
@@ -64,7 +64,7 @@ nonprofitRouter.get("/id/:nonprofit_id", async (req, res) => {
   }
 });
 
-// Add a new nonprofit by name
+// Add a new nonprofit by id
 nonprofitRouter.post("/add", async (req, res) => {
   const nonProfitData = req.body;
   const name = nonProfitData.name;
@@ -84,9 +84,9 @@ nonprofitRouter.post("/add", async (req, res) => {
   }
 });
 
-// Edit a nonprofit by name
-nonprofitRouter.put("/:nonprofitname/edit", async (req, res) => {
-  const { nonprofitname } = req.params;
+// Edit a nonprofit by id
+nonprofitRouter.put("/:nonprofit_id/edit", async (req, res) => {
+  const { nonprofit_id } = req.params;
   const nonProfitData = req.body;
   try {
     const exists = await checkNonProfitId(nonprofit_id, next);
@@ -109,12 +109,15 @@ nonprofitRouter.put("/:nonprofitname/edit", async (req, res) => {
 });
 
 // Delete a nonprofit by id
-nonprofitRouter.delete("/:nonprofit_id/delete", async (req, res) => {
+nonprofitRouter.delete("/:nonprofit_id/delete", async (req, res, next) => {
   const { nonprofit_id } = req.params;
   try {
     const exists = await checkNonProfitId(nonprofit_id, next);
 
     if (exists) {
+      await prisma.nonprofit_employee.deleteMany({
+        where: { nonprofit_ID: nonprofit_id },
+      });
       await prisma.nonprofit.delete({
         where: {
           id: nonprofit_id,
@@ -122,7 +125,7 @@ nonprofitRouter.delete("/:nonprofit_id/delete", async (req, res) => {
       });
       res.status(214).send(`Nonprofit ${nonprofit_id} deleted`);
     } else {
-      throw NonProfitNotFoundError(nonprofit_id);
+      throw new NonProfitNotFoundError(nonprofit_id);
     }
   } catch (e) {
     return next(e);

--- a/backend/routes/nonprofit.js
+++ b/backend/routes/nonprofit.js
@@ -12,7 +12,7 @@ const prisma = new PrismaClient();
 const nonprofitRouter = express.Router();
 
 // Default is to get all nonprofits
-nonprofitRouter.get("/", async (req, res) => {
+nonprofitRouter.get("/", async (req, res, next) => {
   res.status(200).json({ message: "Nonprofit route" });
 });
 
@@ -65,7 +65,7 @@ nonprofitRouter.get("/id/:nonprofit_id", async (req, res, next) => {
 });
 
 // Add a new nonprofit by id
-nonprofitRouter.post("/add", async (req, res) => {
+nonprofitRouter.post("/add", async (req, res, next) => {
   const nonProfitData = req.body;
   const name = nonProfitData.name;
   try {
@@ -85,7 +85,7 @@ nonprofitRouter.post("/add", async (req, res) => {
 });
 
 // Edit a nonprofit by id
-nonprofitRouter.put("/:nonprofit_id/edit", async (req, res) => {
+nonprofitRouter.put("/:nonprofit_id/edit", async (req, res, next) => {
   const { nonprofit_id } = req.params;
   const nonProfitData = req.body;
   try {

--- a/backend/routes/nonprofit.js
+++ b/backend/routes/nonprofit.js
@@ -19,33 +19,33 @@ nonprofitRouter.get("/all", async (req, res) => {
 });
 
 // Get one nonprofit by name
-nonprofitRouter.get("/:nonprofitname", async (req, res) => {
-  const { nonprofitname } = req.params;
+nonprofitRouter.get("/:nonprofit_id", async (req, res) => {
+  const { nonprofit_id } = req.params;
   const findNonProfit = await prisma.nonprofit.findUnique({
     where: {
-      name: nonprofitname,
+      id: nonprofit_id,
     },
   });
-  res.status(200).json(findNonProfit);
+  if (findNonProfit) {
+    res.status(200).json(findNonProfit);
+  } else {
+    res.status(404).send(`Nonprofit ${nonprofit_id} not found`);
+  }
 });
 
 // Add a new nonprofit by name
 nonprofitRouter.post("/add", async (req, res) => {
   const nonProfitData = req.body;
   const name = nonProfitData.name;
+  const exists = await checkNonProfitName(name);
 
-  const findNonProfits = await prisma.nonprofit.findUnique({
-    where: {
-      name: name,
-    },
-  });
-  if (!findNonProfits) {
+  if (!exists) {
     const createNonProfit = await prisma.nonprofit.create({
       data: nonProfitData,
     });
     res.status(201).json(createNonProfit);
   } else {
-    req.status(400).json({ message: "Nonprofit already exists" });
+    res.status(400).send(`Nonprofit ${name} already exists`);
   }
 });
 
@@ -56,9 +56,8 @@ nonprofitRouter.put("/:nonprofitname/edit", async (req, res) => {
   try {
     const updateOne = await prisma.nonprofit.update({
       where: {
-        name: nonprofitname,
+        id: nonprofit_id,
       },
-
       data: nonProfitData,
     });
     res.json(updateOne);
@@ -74,7 +73,7 @@ nonprofitRouter.delete("/:nonprofitname/delete", async (req, res) => {
   try {
     await prisma.nonprofit.delete({
       where: {
-        name: nonprofitname,
+        id: nonprofit_id,
       },
     });
     res.status(214).send();

--- a/backend/utils/nonprofit_utils.js
+++ b/backend/utils/nonprofit_utils.js
@@ -6,14 +6,18 @@ const prisma = new PrismaClient();
  * @param {String} name The name to check
  * @returns True if it exists, false otherwise
  */
-export async function checkNonProfitName(name) {
-  let resultData = await prisma.nonprofit.findUnique({
-    where: {
-      name: name,
-    },
-  });
-  console.log(resultData != null);
-  return resultData != null;
+export async function checkNonProfitName(name, next) {
+  try {
+    let resultData = await prisma.nonprofit.findUnique({
+      where: {
+        name: name,
+      },
+    });
+    console.log(resultData != null);
+    return resultData != null;
+  } catch (e) {
+    next(e);
+  }
 }
 
 /**
@@ -21,13 +25,17 @@ export async function checkNonProfitName(name) {
  * @param {String} id The id to check
  * @returns True if it exists, false otherwise
  */
-export async function checkNonProfitId(id) {
-  let resultData = await prisma.nonprofit.findUnique({
-    where: {
-      id: id,
-    },
-  });
-  return resultData != null;
+export async function checkNonProfitId(id, next) {
+  try {
+    let resultData = await prisma.nonprofit.findUnique({
+      where: {
+        id: id,
+      },
+    });
+    return resultData != null;
+  } catch (e) {
+    next(e);
+  }
 }
 
 /**
@@ -35,12 +43,16 @@ export async function checkNonProfitId(id) {
  * @param {String} name The name to search for
  * @returns The data associated with the nonprofit
  */
-async function getNonProfitData(name) {
-  return await prisma.nonprofit.findUnique({
-    where: {
-      name: name,
-    },
-  });
+async function getNonProfitData(name, next) {
+  try {
+    return await prisma.nonprofit.findUnique({
+      where: {
+        name: name,
+      },
+    });
+  } catch (e) {
+    next(e);
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

+ Added custom error handling to non profit class to make error checking 
+ NonProfitNotFoundError for when the non profit to be changed can not be found
+ NonProfitAlreadyExistsError for when the non profit to be created already exists 
+ Note: Will merge to main just checking against non-profit-path to keep things simple

## Milestones
Custom error handling will make adding and working with new routes easier in the future and helps simplify backend infrastructure. 

## Resources
[Catching Errors in Express](https://expressjs.com/en/guide/error-handling.html)
[Example from codepath](https://github.com/codepath/adopt-a-pet-authentication-exemplar/blob/main/server/middleware/CustomErrors.js)

## Test Plan
Tested routes in Insomnia for both of the new error types as well as an error that Prisma sends out that I am not catching explicitly. 

### NonProfitNotFoundError
<img width="1415" alt="Screenshot 2025-06-25 at 11 08 48 AM" src="https://github.com/user-attachments/assets/eb3bf6b9-93ff-4344-bec1-77e9c944c514" />
<img width="1415" alt="Screenshot 2025-06-25 at 11 08 56 AM" src="https://github.com/user-attachments/assets/c433553d-c278-4972-8e3d-acfc910d5850" />
<img width="1415" alt="Screenshot 2025-06-25 at 11 09 06 AM" src="https://github.com/user-attachments/assets/c4fc84d4-8ee5-45d0-9e4d-cef16cfe869e" />

### NonProfitAlreadyExistsError
<img width="1415" alt="Screenshot 2025-06-25 at 11 11 27 AM" src="https://github.com/user-attachments/assets/1b4952fd-0577-4bbf-be48-76c62c0219e0" />
<img width="1415" alt="Screenshot 2025-06-25 at 11 11 42 AM" src="https://github.com/user-attachments/assets/5633e208-bf93-4ff5-8126-3aadeacb8a03" />

