### PR TITLE
Location Restrictions for Google API fixed 

### DIFF
--- a/backend/utils/search/address-utils.js
+++ b/backend/utils/search/address-utils.js
@@ -2,6 +2,11 @@ const googleApiKey = process.env.MAPS_API_KEY;
 import { errorReturn, successReturn } from "#utils/validate-utils.js";
 import { getAreaAroundPoint } from "#search/dist-utils.js";
 import { nonprofitRadius } from "#utils/constants.js";
+import {
+  serviceInRadius,
+  getCords,
+  getRadiusAroundPointObject,
+} from "#search/dist-utils.js";
 
 /**
  * Searches for an address using the search text API
@@ -12,7 +17,6 @@ import { nonprofitRadius } from "#utils/constants.js";
  */
 export default async function formatAddress(address, nonprofit = null) {
   const searchURL = "https://places.googleapis.com/v1/places:searchText";
-  const nonprofitGiven = nonprofit !== null;
 
   // Data for the POST request
   let data = getSearchTextRequestBody(address, nonprofit);
@@ -36,7 +40,7 @@ export default async function formatAddress(address, nonprofit = null) {
       return response.json(); // Parse JSON data from the response
     })
     .then((data) => {
-      return validateAndExtractSearchData(data, nonprofitGiven);
+      return validateAndExtractSearchData(data, nonprofit);
     })
     .catch((error) => {
       // Handle error
@@ -51,10 +55,10 @@ export default async function formatAddress(address, nonprofit = null) {
  * @param {object} nonprofit - The nonprofit to search around
  * @returns - If the data is valid, return the data, otherwise return an error object containing the error
  */
-function validateAndExtractSearchData(data, nonprofitGiven) {
+function validateAndExtractSearchData(data, nonprofit) {
   // If the address is not found, return an error
   if (Object.keys(data).length === 0) {
-    if (!nonprofitGiven) {
+    if (nonprofit === null) {
       return errorReturn("Can not locate address");
     } else {
       return errorReturn(
@@ -72,6 +76,17 @@ function validateAndExtractSearchData(data, nonprofitGiven) {
     }
     return errorReturn(manyPlacesStr); // Return an error object
   } else {
+    const gottenCords = getCords(data.places[0]);
+    const radius = getRadiusAroundPointObject(
+      getCords(nonprofit.addressInfo),
+      nonprofitRadius
+    );
+    if (serviceInRadius(radius, gottenCords) === false) {
+      return errorReturn(
+        `We can not locate that address within ${nonprofitRadius} miles of the nonprofit please be more specific or try a different address`
+      );
+    }
+
     // if there is only one option return the data
     return successReturn(data.places[0]); // Return the actual data instead of a container
   }
@@ -92,11 +107,7 @@ function getSearchTextRequestBody(address, nonprofit) {
     const info = nonprofit.addressInfo;
     const location = info?.location;
     if (location !== undefined) {
-      const latLong = getAreaAroundPoint(
-        location.latitude,
-        location.longitude,
-        nonprofitRadius
-      );
+      const latLong = getRadiusAroundPointObject(location, nonprofitRadius);
       data.locationRestriction = { rectangle: latLong };
     }
   }

--- a/backend/utils/search/address-utils.js
+++ b/backend/utils/search/address-utils.js
@@ -59,7 +59,7 @@ function validateAndExtractSearchData(data, nonprofit) {
   // If the address is not found, return an error
   if (Object.keys(data).length === 0) {
     if (nonprofit === null) {
-      return errorReturn("Can not locate address");
+      return errorReturn("Can not locate address of nonprofit to create");
     } else {
       return errorReturn(
         `That address not found within ${nonprofitRadius} miles of nonprofit`

--- a/backend/utils/search/dist-utils.js
+++ b/backend/utils/search/dist-utils.js
@@ -40,11 +40,25 @@ export function addMilesToLat(lat, long, miles) {
 }
 
 /**
+ * Helper function so you can pass cord directly as an object
+ * @param {object} encodedPoint - The object of the point, in the form {latitude: number, longitude: number}
+ * @param {number} radius - The distance in miles to add to the point
+ * @returns The calculated rectangle in the form {low: {latitude, longitude}, high: {latitude, longitude}}
+ */
+export function getRadiusAroundPointObject(encodedPoint, radius) {
+  return getAreaAroundPoint(
+    encodedPoint.latitude,
+    encodedPoint.longitude,
+    radius
+  );
+}
+
+/**
  * Adds a certain number of miles to a point's latitude and longitude to make a rectangle around the point
  * @param {number} lat - The latitude of the point
  * @param {number} long - The longitude of the point
  * @param {number} radius - The distance in miles to add to the point
- * @returns
+ * @returns The calculated rectangle in the form {low: {latitude, longitude}, high: {latitude, longitude}}
  */
 export function getAreaAroundPoint(lat, long, radius) {
   return {


### PR DESCRIPTION
## Description

+ Added manual checks for address returned by google API
+ Sometimes if you are not specific enough it would choose a place close to you but nowhere near the nonprofit 
+ Ex: 1224 Main street - Would take the Redwood city one when there is none in the DC area(Where the nonprofit I was searching in is located)

## Milestones
+ Address validation 
+ TC1 Search

## Resources
+ None

## Test Plan
Tried typing in the address the revealed the problem to me and it now prints an error instead of trying to route me to an address 1000 miles away
