### PR TITLE
Prisma One Client Across Site

### DIFF
--- a/backend/api/routes/api-v1.js
+++ b/backend/api/routes/api-v1.js
@@ -1,5 +1,5 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
+import { prisma } from "#utils/constants.js";
 import express from "express";
 
 // Local Imports
@@ -13,7 +13,6 @@ import serviceRouter from "#apiroutes/service.js";
 import { NonProfitNotFoundError } from "#errors/nonprofit-errors.js";
 import { getNonProfit } from "#utils/nonprofit-utils.js";
 
-const prisma = new PrismaClient();
 const apiRouter = express.Router();
 
 // Default route for /api/v1

--- a/backend/api/routes/nonprofit-employee.js
+++ b/backend/api/routes/nonprofit-employee.js
@@ -1,5 +1,5 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
+import { prisma } from "#utils/constants.js";
 import express from "express";
 
 // Local Imports
@@ -18,7 +18,6 @@ import {
 import { createErrorReturn } from "#utils/error-utils.js";
 import { checkLogin } from "#utils/session-utils.js";
 
-const prisma = new PrismaClient();
 const employeeRouter = express.Router();
 
 // Default is to get all nonprofits

--- a/backend/api/routes/nonprofit.js
+++ b/backend/api/routes/nonprofit.js
@@ -1,5 +1,5 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
+import { prisma } from "#utils/constants.js";
 import express from "express";
 
 // Local Imports
@@ -16,7 +16,6 @@ import {
 import formatAddress from "#search/address-utils.js";
 import { checkLogin } from "#utils/session-utils.js";
 
-const prisma = new PrismaClient();
 const nonprofitRouter = express.Router();
 
 // Default is to get all nonprofits

--- a/backend/api/routes/refugee.js
+++ b/backend/api/routes/refugee.js
@@ -1,8 +1,7 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
+import { prisma } from "#utils/constants.js";
 import express from "express";
 
-const prisma = new PrismaClient();
 const refugeeRouter = express.Router();
 
 // TODO - Implement routes for refugee as a part of stretch goal

--- a/backend/api/routes/service.js
+++ b/backend/api/routes/service.js
@@ -1,5 +1,5 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
+import { prisma } from "#utils/constants.js";
 import express from "express";
 
 // Local Imports
@@ -22,7 +22,6 @@ import recServices from "#recs/rec-services.js";
 import { checkSession, checkLogin } from "#utils/session-utils.js";
 import { createSearchLog } from "#search/search-utils.js";
 
-const prisma = new PrismaClient();
 const serviceRouter = express.Router();
 
 serviceRouter.get("/", (req, res) => {

--- a/backend/prisma/seed/seed.js
+++ b/backend/prisma/seed/seed.js
@@ -1,4 +1,4 @@
-import { PrismaClient } from "#prisma/client.js";
+import { prisma } from "#utils/constants.js";
 // Node Module Imports
 
 // Local Imports
@@ -10,7 +10,6 @@ import nonprofitJson from "#seed/nonprofits.json" with { type: "json" };
 import employees from "#seed/employees.json" with { type: "json" };
 import formatAddress from "#utils/search/address-utils.js";
 
-const prisma = new PrismaClient();
 
 async function main() {
   const currentServices = await prisma.service.findMany();

--- a/backend/utils/constants.js
+++ b/backend/utils/constants.js
@@ -1,3 +1,6 @@
+import { PrismaClient } from "#prisma/client.js";
+export const prisma = new PrismaClient(); // Universal prisma client for all queries
+
 export const nonprofitRadius = 50; // Radius in miles to search around the nonprofit
 export const googleAPIMaxPageNumber = 3; // Max number of pages returned by Google API search
 

--- a/backend/utils/employee-valid-utils.js
+++ b/backend/utils/employee-valid-utils.js
@@ -1,7 +1,5 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
-
-const prisma = new PrismaClient();
+import { prisma } from "#utils/constants.js";
 
 /**
  * Checks if a Employee exists with that name

--- a/backend/utils/filter-create-utils.js
+++ b/backend/utils/filter-create-utils.js
@@ -1,11 +1,10 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
+import { prisma } from "#utils/constants.js";
 
 // Local Imports
 import data from "#utils/filter-default-data.json" with { type: "json" };
 import {prettyPrintService} from "#utils/service-utils.js"
 
-const prisma = new PrismaClient();
 
 /**
  * Creates the filters for a given nonprofit based on their services

--- a/backend/utils/nonprofit-stat-utils.js
+++ b/backend/utils/nonprofit-stat-utils.js
@@ -1,7 +1,5 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
-
-const prisma = new PrismaClient();
+import { prisma } from "#utils/constants.js";
 
 /**
  * Generates the stats for a nonprofit

--- a/backend/utils/nonprofit-utils.js
+++ b/backend/utils/nonprofit-utils.js
@@ -1,10 +1,8 @@
 // Local Imports
-import { PrismaClient } from "#prisma/client.js";
+import { prisma } from "#utils/constants.js";
 
 // Local Imports
 import { NonProfitNotFoundError } from "#errors/nonprofit-errors.js";
-
-const prisma = new PrismaClient();
 
 /**
  * Checks if a nonprofit exists with that name

--- a/backend/utils/recs/rec-existing-popular.js
+++ b/backend/utils/recs/rec-existing-popular.js
@@ -1,7 +1,5 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
-
-const prisma = new PrismaClient();
+import { prisma } from "#utils/constants.js";
 
 /**
  * Finds the most popular info for a nonprofits fields of id, zipcode, services_offered, and languages

--- a/backend/utils/recs/rec-existing.js
+++ b/backend/utils/recs/rec-existing.js
@@ -1,12 +1,10 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
+import { prisma } from "#utils/constants.js";
 
 // Local Imports
 import { perimeterOverlap, serviceInPerimeter } from "#search/dist-utils.js";
 import { getCords, getAreaAroundPoint } from "#search/dist-utils.js";
 import { nonprofitRadius } from "#utils/constants.js";
-
-const prisma = new PrismaClient();
 
 /**
  * Find what other nonprofits are within the nonprofit's perimeter

--- a/backend/utils/recs/rec-services.js
+++ b/backend/utils/recs/rec-services.js
@@ -1,6 +1,5 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
-const prisma = new PrismaClient();
+import { prisma } from "#utils/constants.js";
 
 // Local Imports
 import findExistingServicesWithinRadius from "#recs/rec-existing.js";

--- a/backend/utils/search/search-services.js
+++ b/backend/utils/search/search-services.js
@@ -1,6 +1,5 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
-const prisma = new PrismaClient();
+import { prisma } from "#utils/constants.js";
 
 // Local Imports
 import formatAddress from "#utils/search/address-utils.js";

--- a/backend/utils/search/search-utils.js
+++ b/backend/utils/search/search-utils.js
@@ -1,10 +1,8 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
+import { prisma } from "#utils/constants.js";
 
 // Local Imports
 import { extractZipcode } from "#search/address-utils.js";
-
-const prisma = new PrismaClient();
 
 /**
  * Creates a search log for the given search parameters

--- a/backend/utils/service-utils.js
+++ b/backend/utils/service-utils.js
@@ -1,12 +1,10 @@
 // Node Module Imports
-import { PrismaClient } from "#prisma/client.js";
+import { prisma } from "#utils/constants.js";
 
 // Local Imports
 import formatAddress from "#utils/search/address-utils.js";
 import { getAndValidateDate } from "#search/search-services.js";
 import { errorReturn, successReturn } from "./validate-utils.js";
-
-const prisma = new PrismaClient();
 
 /**
  * Checks if a service exists with that name


### PR DESCRIPTION
## Description

+ Discovered line in Prisma client recently "Creating multiple instances of PrismaClient can exhaust your database connection pool, especially in serverless or edge environments, potentially slowing down other queries"
+ So I changed my program so everywhere I created a prisma client I now just use a Prisma from my constants file

## Milestones
+ Style Stretch Feature 

## Resources
+ [Prisma Doc referencing](https://www.prisma.io/docs/orm/prisma-client/queries/query-optimization-performance#:~:text=Define%20a%20single%20PrismaClient%20instance%20in%20a%20dedicated%20file%20and%20re%2Dexport%20it%20for%20reuse%3A)

## Test Plan
+ All queries still work in database
