### PR TITLE
Dark Theme for Site 

### DIFF
--- a/frontend/src/components/FooterNonProfit/FooterNonProfit.css
+++ b/frontend/src/components/FooterNonProfit/FooterNonProfit.css
@@ -26,6 +26,9 @@
 .FooterNonProfit .logo {
   height: 100px;
   border-radius: 20px;
+  background-color: var(--icon-background);
+  border: 2px solid var(--border-light);
+  margin: 10px 0;
 }
 
 /*  The name of the nonprofit */

--- a/frontend/src/components/FooterNonProfit/FooterNonProfit.css
+++ b/frontend/src/components/FooterNonProfit/FooterNonProfit.css
@@ -44,3 +44,15 @@
   font-size: 14px;
   font-style: italic;
 }
+
+/* Dark Mode Icon */
+.FooterNonProfit .darkMode svg {
+  height: 40px;
+  width: 40px;
+  color: var(--text-mid);
+}
+
+/* Light Mode Icon */
+.FooterNonProfit .darkMode svg:hover {
+  color: var(--text-dark);
+}

--- a/frontend/src/components/FooterNonProfit/FooterNonProfit.jsx
+++ b/frontend/src/components/FooterNonProfit/FooterNonProfit.jsx
@@ -34,6 +34,9 @@ function FooterNonProfit({ data }) {
   // State Variables
   const [darkMode, setDarkMode] = useState(darkModeGiven);
 
+  /**
+   * When the dark mode button is clicked, toggle the dark mode state and change the color variables to fit accordingly
+   */
   function changeDarkMode() {
     setDarkMode((prv) => !prv);
     setColorVariables(color, !darkMode);

--- a/frontend/src/components/FooterNonProfit/FooterNonProfit.jsx
+++ b/frontend/src/components/FooterNonProfit/FooterNonProfit.jsx
@@ -1,5 +1,5 @@
 // Node Module Imports
-import React, { use, useEffect } from "react";
+import React, { use, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import {
   MdLocationOn,
@@ -7,6 +7,8 @@ import {
   MdLocalPhone,
   MdEmail,
   MdOutlineQuestionMark,
+  MdDarkMode,
+  MdLightMode,
 } from "react-icons/md";
 
 // Local Imports
@@ -14,6 +16,7 @@ import "./FooterNonProfit.css";
 import { setColorVariables } from "#utils/colorUtils";
 
 function FooterNonProfit({ data }) {
+  // Constant Variables
   const strongEmail = "strongStartWeb@gmail.com";
   const name = data.name;
   const email = data.email;
@@ -25,8 +28,19 @@ function FooterNonProfit({ data }) {
   const website = data.website;
   const logo = data.logo;
   const color = data.color;
+  const darkModeGiven = window.matchMedia(
+    "(prefers-color-scheme: dark)"
+  ).matches;
+  // State Variables
+  const [darkMode, setDarkMode] = useState(darkModeGiven);
+
+  function changeDarkMode() {
+    setDarkMode((prv) => !prv);
+    setColorVariables(color, !darkMode);
+  }
+
   useEffect(() => {
-    setColorVariables(color);
+    setColorVariables(color, darkMode);
   }, [color]);
 
   return (
@@ -73,6 +87,9 @@ function FooterNonProfit({ data }) {
             <MdOutlineQuestionMark />
             <a href={"mailto:" + strongEmail}> {strongEmail} </a>
           </p>
+        </div>
+        <div className="darkMode" onClick={changeDarkMode}>
+          {darkMode ? <MdLightMode /> : <MdDarkMode />}
         </div>
       </div>
     </div>

--- a/frontend/src/components/SearchFilters/SearchFilters.css
+++ b/frontend/src/components/SearchFilters/SearchFilters.css
@@ -77,7 +77,7 @@ Key:
 
 /* The Placeholder text when no options are selected  */
 .custom-select__placeholder {
-  color: var(--text-dark) !important;
+  color: var(--text-greyer) !important;
 }
 
 /* The background of the selected param in the bar */

--- a/frontend/src/components/SearchFilters/SearchFilters.css
+++ b/frontend/src/components/SearchFilters/SearchFilters.css
@@ -45,11 +45,65 @@
   width: 25px;
 }
 
+/* START The select bar
+Key:
++ In the bar- Pertains to everything inside the selection box which is always visible
++ Select menu- the menu that opens up that you can select options from */
+/* The whole Select bar */
 .custom-select__control {
   width: 70vw;
   margin: 10px;
-  /* TODO make styles match the rest */
+  color: var(--background);
 }
+
+/* When the select is in focus */
+.custom-select__control--is-focused {
+  border: 2px solid var(--border-dark) !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+/* The background color for the bar itself and the options list */
+.custom-select__value-container,
+.custom-select__indicators,
+.custom-select__menu-list {
+  background-color: var(--background);
+}
+/* Hover on the bar  */
+.custom-select__control:hover .custom-select__indicators,
+.custom-select__control:hover .custom-select__value-container {
+  background-color: var(--background-hover);
+}
+
+/* The Placeholder text when no options are selected  */
+.custom-select__placeholder {
+  color: var(--text-dark) !important;
+}
+
+/* The background of the selected param in the bar */
+.custom-select__multi-value {
+  background-color: var(--background-darker) !important; /* neutral-400 */
+  border-radius: 0.375rem; /* rounded-md */
+}
+/*  The text of the Selected Param  in the bar*/
+.custom-select__multi-value__label {
+  color: var(--text) !important;
+}
+
+/* The border around the select menu */
+.custom-select__menu-list {
+  border: 2px solid var(--border-dark);
+}
+/* Hovering over an option in the select menu */
+.custom-select__option:hover {
+  background-color: var(--background-darker);
+}
+/* When there is no hover but the menu is open this is what is selected
++ This is also what appears when you use arrow keys to navigate  */
+.css-d7l1ni-option {
+  background-color: var(--background-selected) !important;
+}
+/* END Select Bar */
 
 .addressInput {
   width: 69vw;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,6 +17,7 @@
   --border-mid: #0098f7;
   --border-dark: #007e87;
   --border-very-dark: #003b3f;
+  scrollbar-color: var(--border-light) var(--background-darker);
 }
 
 *:focus {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,6 +37,7 @@ button {
   font-size: 110%;
   border: var(--border-light) solid 1px;
   border-radius: 20px;
+  color: var(--text);
 }
 button:hover {
   background-color: var(--background-hover);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,7 @@
   line-height: 1.5;
   font-weight: 400;
   --background: #effeff;
+  --icon-background: #effeff;
   --text: #00292c;
   --text-dark: #00747d;
   --text-mid: #00c2d0;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,6 +5,7 @@
   --background: #effeff;
   --icon-background: #effeff;
   --text: #00292c;
+  --text-greyer: #1a2425;
   --text-dark: #00747d;
   --text-mid: #00c2d0;
   --text-light: #51f3ff;
@@ -51,6 +52,10 @@ button {
 }
 button:hover {
   background-color: var(--background-hover);
+}
+input::placeholder,
+textarea::placeholder {
+  color: var(--text-greyer);
 }
 
 .errorText {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -30,6 +30,15 @@ body {
   text-align: center;
 }
 
+select {
+  padding: 5px 10px;
+  background-color: var(--background-darker);
+  color: var(--text);
+  border: var(--border-light) solid 1px;
+  border-radius: 20px;
+  font-size: 110%;
+}
+
 button {
   cursor: pointer;
   border: var(--text) solid 0px;

--- a/frontend/src/pages/refugee/Contact/Contact.css
+++ b/frontend/src/pages/refugee/Contact/Contact.css
@@ -4,5 +4,6 @@
 .Contact .contactButton {
   width: 50%;
   height: 50%;
-  font-size: 15vh;
+  font-size: min(10vw, 15vh);
+  color: var(--text);
 }

--- a/frontend/src/pages/refugee/Contact/Contact.css
+++ b/frontend/src/pages/refugee/Contact/Contact.css
@@ -5,5 +5,4 @@
   width: 50%;
   height: 50%;
   font-size: min(10vw, 15vh);
-  color: var(--text);
 }

--- a/frontend/src/pages/refugee/Home/Home.css
+++ b/frontend/src/pages/refugee/Home/Home.css
@@ -1,4 +1,12 @@
 .Home {
   height: auto;
   width: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.Home .homeHeader {
+  font-size: 40px;
+  width: 75%;
+  border-bottom: 2px solid var(--border-light);
 }

--- a/frontend/src/pages/refugee/Home/Home.jsx
+++ b/frontend/src/pages/refugee/Home/Home.jsx
@@ -43,8 +43,8 @@ function Home() {
     }
   }
   return (
-    <div className="SearchService">
-      <h3>Home</h3>
+    <div className="Home">
+      <h1 className="homeHeader">Home</h1>
       <SearchFilters
         loading={loading}
         setLoading={setLoading}

--- a/frontend/src/utils/colorUtils.js
+++ b/frontend/src/utils/colorUtils.js
@@ -2,27 +2,45 @@
  * Sets the color variables for the theme based on the main color given
  * @param {string} mainColorGiven - The main color to use for the theme in HEX. If not given, it will use the default color.
  */
-export function setColorVariables(mainColorGiven) {
+export function setColorVariables(mainColorGiven, darkModeValue = false) {
   console.log(mainColorGiven);
+  /**
+   * Adjust the value based on if dark mode is enabled
+   * @param {number} value - The value to adjust
+   * @returns The adjusted value
+   */
+  function darkMode(value) {
+    return darkModeValue ? 100 - value : value;
+  }
+  /**
+   * Adjust the value based on if dark mode is enabled
+   * @param {number} value - The value to adjust
+   * @param {number} adjust - The amount to adjust the value by
+   * @returns The adjusted value
+   */
+  function darkModeAdjust(value, adjust = 100) {
+    return darkModeValue ? value - adjust : value + adjust;
+  }
+
   let mainColor = mainColorGiven ? mainColorGiven : "#effeff";
   // Get the hue of the main color
   const hue = hexToHue(mainColor);
 
   // Set the colors
   let colors = {
-    background: `hsl(${hue}, 100%, 97%)`,
-    text: `hsl(${hue}, 100%, 3%)`,
-    "text-dark": `hsl(${hue}, 100%, 25%)`,
-    "text-mid": `hsl(${hue}, 100%, 40%)`,
-    "text-light": `hsl(${hue}, 100%, 65%)`,
-    "background-greyer": `hsl(${hue}, 75%, 10%)`,
-    "background-darker": `hsl(${hue}, 100%, 88%)`,
-    "background-hover": `hsl(${hue}, 100%, 73%)`,
-    "background-selected": `hsl(${hue}, 60%, 65%)`,
-    "border-light": `hsl(${hue}, 100%, 40%)`,
-    "border-mid": `hsl(${hue}, 100%, 50%)`,
-    "border-dark": `hsl(${hue}, 100%, 25%)`,
-    "border-very-dark": `hsl(${hue}, 100%, 12%)`,
+    background: `hsl(${hue}, 100%, ${darkMode(97)}%)`,
+    text: `hsl(${hue}, 100%, ${darkMode(3)}%)`,
+    "text-dark": `hsl(${hue}, 100%, ${darkMode(25)}%)`,
+    "text-mid": `hsl(${hue}, 100%, ${darkMode(40)}%)`,
+    "text-light": `hsl(${hue}, 100%, ${darkMode(65)}%)`,
+    "background-greyer": `hsl(${hue}, 75%, ${darkMode(10)}%)`,
+    "background-darker": `hsl(${hue}, 100%, ${darkMode(88)}%)`,
+    "background-hover": `hsl(${hue}, 100%, ${darkMode(73)}%)`,
+    "background-selected": `hsl(${hue}, 60%, ${darkMode(65)}%)`,
+    "border-light": `hsl(${hue}, 100%, ${darkMode(40)}%)`,
+    "border-mid": `hsl(${darkModeAdjust(hue, 10)}, 100%, ${darkMode(50)}%)`,
+    "border-dark": `hsl(${hue}, 100%, ${darkMode(25)}%)`,
+    "border-very-dark": `hsl(${hue}, 100%, ${darkMode(12)}%)`,
   };
   // Set all the color variables
   for (const [varName, color] of Object.entries(colors)) {

--- a/frontend/src/utils/colorUtils.js
+++ b/frontend/src/utils/colorUtils.js
@@ -31,6 +31,7 @@ export function setColorVariables(mainColorGiven, darkModeValue = false) {
     background: `hsl(${hue}, 100%, ${darkMode(97)}%)`,
     text: `hsl(${hue}, 100%, ${darkMode(3)}%)`,
     "icon-background": `hsl(${hue}, 100%, 97%)`,
+    "text-greyer": `hsl(${hue}, 30%, ${darkMode(30)}%)`,
     "text-dark": `hsl(${hue}, 100%, ${darkMode(25)}%)`,
     "text-mid": `hsl(${hue}, 100%, ${darkMode(40)}%)`,
     "text-light": `hsl(${hue}, 100%, ${darkMode(65)}%)`,

--- a/frontend/src/utils/colorUtils.js
+++ b/frontend/src/utils/colorUtils.js
@@ -30,6 +30,7 @@ export function setColorVariables(mainColorGiven, darkModeValue = false) {
   let colors = {
     background: `hsl(${hue}, 100%, ${darkMode(97)}%)`,
     text: `hsl(${hue}, 100%, ${darkMode(3)}%)`,
+    "icon-background": `hsl(${hue}, 100%, 97%)`,
     "text-dark": `hsl(${hue}, 100%, ${darkMode(25)}%)`,
     "text-mid": `hsl(${hue}, 100%, ${darkMode(40)}%)`,
     "text-light": `hsl(${hue}, 100%, ${darkMode(65)}%)`,
@@ -38,7 +39,7 @@ export function setColorVariables(mainColorGiven, darkModeValue = false) {
     "background-hover": `hsl(${hue}, 100%, ${darkMode(73)}%)`,
     "background-selected": `hsl(${hue}, 60%, ${darkMode(65)}%)`,
     "border-light": `hsl(${hue}, 100%, ${darkMode(40)}%)`,
-    "border-mid": `hsl(${darkModeAdjust(hue, 10)}, 100%, ${darkMode(50)}%)`,
+    "border-mid": `hsl(${darkModeAdjust(hue, 10)}, 70%, ${darkMode(50)}%)`,
     "border-dark": `hsl(${hue}, 100%, ${darkMode(25)}%)`,
     "border-very-dark": `hsl(${hue}, 100%, ${darkMode(12)}%)`,
   };

--- a/frontend/src/utils/colorUtils.js
+++ b/frontend/src/utils/colorUtils.js
@@ -35,7 +35,7 @@ export function setColorVariables(mainColorGiven, darkModeValue = false) {
     "text-dark": `hsl(${hue}, 100%, ${darkMode(25)}%)`,
     "text-mid": `hsl(${hue}, 100%, ${darkMode(40)}%)`,
     "text-light": `hsl(${hue}, 100%, ${darkMode(65)}%)`,
-    "background-greyer": `hsl(${hue}, 75%, ${darkMode(10)}%)`,
+    "background-greyer": `hsl(${hue}, 50%, ${darkMode(90)}%)`,
     "background-darker": `hsl(${hue}, 100%, ${darkMode(88)}%)`,
     "background-hover": `hsl(${hue}, 100%, ${darkMode(73)}%)`,
     "background-selected": `hsl(${hue}, 60%, ${darkMode(65)}%)`,


### PR DESCRIPTION
## Description

+ You can now switch between  light and dark theme from the nav bar
  + The default is based on your computers settings 
  +  All colors are calculated in dark mode by inverting the saturation 
+ Updated react-select component to use custom styling
+ Updated Select to use custom styling
+ Made buttons all use the text color variable 
+ Adjusted header for refugee home for styling
+ Gave transparent images a background and all images a border to they can be clearly seen in light or dark mode 
+ Custom scrollbar colors!

## Milestones
+ Stretch Feature 

## Resources
+ [Live Site](https://strong-start-git-np-dark-jack-campbells-projects.vercel.app/)

## Test Plan
+ Went thru each page of site and made sure I could still read everything 
+ Also checked across multiple nonprofits to makes sure everything worked 

### View All
<img width="854" height="957" alt="Screenshot 2025-07-25 at 1 07 35 PM" src="https://github.com/user-attachments/assets/3c9d4180-e7db-4c63-8fac-982a66bd5adb" />

### Search
<img width="854" height="957" alt="Screenshot 2025-07-25 at 1 07 50 PM" src="https://github.com/user-attachments/assets/163d4e95-5572-4bb2-9814-e05c8714bedc" />

### Search Results
<img width="854" height="957" alt="Screenshot 2025-07-25 at 1 08 25 PM" src="https://github.com/user-attachments/assets/04507e24-2302-441e-bb9c-ccf0a12d8950" />

### Contact
<img width="854" height="957" alt="Screenshot 2025-07-25 at 1 08 31 PM" src="https://github.com/user-attachments/assets/db145d5c-55e0-4c71-b4a1-de02c62548cc" />

### Recommendation 
<img width="854" height="957" alt="Screenshot 2025-07-25 at 1 10 26 PM" src="https://github.com/user-attachments/assets/ee4b904d-0260-4d0f-a34e-d901e06e464e" />

### Single Service
<img width="854" height="957" alt="Screenshot 2025-07-25 at 1 10 35 PM" src="https://github.com/user-attachments/assets/4d915116-2d98-4d42-8713-96638f400ed3" />
